### PR TITLE
Play cards: whole card opens details, with showtimes inside the modal

### DIFF
--- a/_includes/play_card.html
+++ b/_includes/play_card.html
@@ -42,41 +42,6 @@
         Szczegóły spektaklu →
       </button>
     {% endif %}
-    {% assign pc_months = 'stycznia,lutego,marca,kwietnia,maja,czerwca,lipca,sierpnia,września,października,listopada,grudnia'
-      | split: ','
-    %}
-    {% assign pc_days = 'Niedziela,Poniedziałek,Wtorek,Środa,Czwartek,Piątek,Sobota' | split: ',' %}
-    {% for event in events %}
-      {% assign pc_dw = event.data | date: '%w' | plus: 0 %}
-      {% if pc_dw == 0 or pc_dw == 6 %}
-        {% assign event_type = 'weekend' %}
-      {% else %}
-        {% assign event_type = 'weekday' %}
-      {% endif %}
-      {% assign pc_mi = event.data | date: '%-m' | minus: 1 %}
-      <article class="pc-ticket" data-event-type="{{ event_type }}">
-        <div class="pc-block">
-          <span class="pc-time">{{ event.data | date: '%R' }}</span>
-        </div>
-        <div class="pc-tbody">
-          <span class="pc-when">
-            {{- pc_days[pc_dw] }}, {{ event.data | date: '%-d' }}
-            {{ pc_months[pc_mi] -}}
-          </span>
-          {% if event.manual_price == true %}
-            <span class="pc-soon">{{ event.link }}</span>
-          {% elsif event_type == 'weekend' %}
-            {% if event.link and event.link != '-' %}
-              <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer" class="pc-buy">Kup bilet 🎫</a>
-            {% else %}
-              <span class="pc-soon">Bilety online wkrótce</span>
-            {% endif %}
-          {% else %}
-            <span class="pc-groups-note">Rezerwacja dla grup zorganizowanych:</span>
-            <a href="tel:501-027-278" class="pc-tel">Zadzwoń 501 027 278 ☎</a>
-          {% endif %}
-        </div>
-      </article>
-    {% endfor %}
+    {% render 'play_tickets.html', events: events %}
   </div>
 </div>

--- a/_includes/play_card.html
+++ b/_includes/play_card.html
@@ -27,7 +27,18 @@
       <p class="pc-headline">{{ s.headline }}</p>
     {% endif %}
     {% if s %}
-      <button type="button" class="pc-details" data-bs-toggle="modal" data-bs-target="#{{ s.id2 }}">
+      {% comment %}
+        .stretched-link turns the whole card into one click target for the
+        details modal. The media facade and the mini-tickets below opt back out
+        via z-index (see _play-card.scss) so the video and "Kup bilet" links
+        keep their own clicks.
+      {% endcomment %}
+      <button
+        type="button"
+        class="pc-details stretched-link"
+        data-bs-toggle="modal"
+        data-bs-target="#{{ s.id2 }}"
+      >
         Szczegóły spektaklu →
       </button>
     {% endif %}

--- a/_includes/play_tickets.html
+++ b/_includes/play_tickets.html
@@ -1,0 +1,42 @@
+{% comment %}
+  Showtime mini-tickets for a play, shared by the play card (play_card.html) and
+  the details modal (spektakl_modal.html) so both list the same tickets.
+  Param: events - array of repertuar events ({data, link, manual_price, tytul}),
+                  already filtered to upcoming and sorted by date. May be empty.
+{% endcomment %}
+{% assign pc_months = 'stycznia,lutego,marca,kwietnia,maja,czerwca,lipca,sierpnia,września,października,listopada,grudnia'
+  | split: ','
+%}
+{% assign pc_days = 'Niedziela,Poniedziałek,Wtorek,Środa,Czwartek,Piątek,Sobota' | split: ',' %}
+{% for event in events %}
+  {% assign pc_dw = event.data | date: '%w' | plus: 0 %}
+  {% if pc_dw == 0 or pc_dw == 6 %}
+    {% assign event_type = 'weekend' %}
+  {% else %}
+    {% assign event_type = 'weekday' %}
+  {% endif %}
+  {% assign pc_mi = event.data | date: '%-m' | minus: 1 %}
+  <article class="pc-ticket" data-event-type="{{ event_type }}">
+    <div class="pc-block">
+      <span class="pc-time">{{ event.data | date: '%R' }}</span>
+    </div>
+    <div class="pc-tbody">
+      <span class="pc-when">
+        {{- pc_days[pc_dw] }}, {{ event.data | date: '%-d' }}
+        {{ pc_months[pc_mi] -}}
+      </span>
+      {% if event.manual_price == true %}
+        <span class="pc-soon">{{ event.link }}</span>
+      {% elsif event_type == 'weekend' %}
+        {% if event.link and event.link != '-' %}
+          <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer" class="pc-buy">Kup bilet 🎫</a>
+        {% else %}
+          <span class="pc-soon">Bilety online wkrótce</span>
+        {% endif %}
+      {% else %}
+        <span class="pc-groups-note">Rezerwacja dla grup zorganizowanych:</span>
+        <a href="tel:501-027-278" class="pc-tel">Zadzwoń 501 027 278 ☎</a>
+      {% endif %}
+    </div>
+  </article>
+{% endfor %}

--- a/_includes/play_tickets.html
+++ b/_includes/play_tickets.html
@@ -29,7 +29,9 @@
         <span class="pc-soon">{{ event.link }}</span>
       {% elsif event_type == 'weekend' %}
         {% if event.link and event.link != '-' %}
-          <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer" class="pc-buy">Kup bilet 🎫</a>
+          <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer" class="pc-buy stretched-link"
+            >Kup bilet 🎫</a
+          >
         {% else %}
           <span class="pc-soon">Bilety online wkrótce</span>
         {% endif %}

--- a/_includes/spektakl_modal.html
+++ b/_includes/spektakl_modal.html
@@ -44,6 +44,13 @@
           </div>
         </div>
 
+        {% if events.size > 0 %}
+          <div class="spektakl-terminy mt-4">
+            <h6 class="mb-2 gallery-title">Najbliższe terminy</h6>
+            {% render 'play_tickets.html', events: events %}
+          </div>
+        {% endif %}
+
         {% if s.video %}
           <div class="ratio ratio-16x9 my-4 spektakl-video">
             {% render 'lite_video.html', video: s.video, title: s.title %}

--- a/_includes/spektakl_modal.html
+++ b/_includes/spektakl_modal.html
@@ -41,15 +41,14 @@
               {%- endif %}
             </p>
             <div class="spektakl-desc">{{ s.content }}</div>
+            {% if events.size > 0 %}
+              <div class="spektakl-terminy mt-3">
+                <h6 class="mb-2 gallery-title">Najbliższe terminy</h6>
+                {% render 'play_tickets.html', events: events %}
+              </div>
+            {% endif %}
           </div>
         </div>
-
-        {% if events.size > 0 %}
-          <div class="spektakl-terminy mt-4">
-            <h6 class="mb-2 gallery-title">Najbliższe terminy</h6>
-            {% render 'play_tickets.html', events: events %}
-          </div>
-        {% endif %}
 
         {% if s.video %}
           <div class="ratio ratio-16x9 my-4 spektakl-video">

--- a/scss/_play-card.scss
+++ b/scss/_play-card.scss
@@ -4,6 +4,31 @@
 // one design system.
 
 .pcard {
+  // The whole card is one click target: .pc-details carries Bootstrap's
+  // .stretched-link, whose ::after (z-index 1) covers the card and fires the
+  // details modal. Only cards that actually have that link (s present) get the
+  // clickable affordance, so a bare card never lies about being tappable.
+  &:has(.stretched-link) {
+    cursor: pointer;
+    transition:
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:hover,
+    &:focus-within {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 18px rgba(56, 2, 0, 0.12);
+    }
+  }
+
+  // Interactive regions opt back out of the stretched-link overlay: the media
+  // facade (YouTube play button) and each mini-ticket (Kup bilet / Zadzwoń)
+  // sit above it so their own clicks win; the rest of the card opens the modal.
+  .ratio,
+  .pc-ticket {
+    z-index: 2;
+  }
+
   .card-body {
     padding: 0.9rem 1rem 0.85rem;
   }

--- a/scss/_play-card.scss
+++ b/scss/_play-card.scss
@@ -78,6 +78,18 @@
 .pc-ticket {
   --timew: 4.6rem;
   position: relative;
+
+  // A buyable showtime: the "Kup bilet" link carries .stretched-link, so the
+  // whole stub is one click target for buying. Signal it and lift on hover.
+  &:has(.pc-buy.stretched-link) {
+    cursor: pointer;
+
+    &:hover {
+      border-color: rgba(224, 123, 120, 0.6);
+      box-shadow: 0 2px 8px rgba(56, 2, 0, 0.1);
+    }
+  }
+
   display: flex;
   align-items: stretch;
   background: #fffdfc;

--- a/t/index.md
+++ b/t/index.md
@@ -243,9 +243,10 @@ layout: t
   </div>
 </div>
 
-{% comment %} Modals for play details {% endcomment %}
+{% comment %} Modals for play details — each lists the play's upcoming showtimes. {% endcomment %}
 {% for s in collections.s2 %}
-  {% render "spektakl_modal.html", s: s %}
+  {% assign modal_events = upcoming_events | where: "tytul", s.title %}
+  {% render "spektakl_modal.html", s: s, events: modal_events %}
 {% endfor %}
 
 <script>

--- a/t/spektakle.md
+++ b/t/spektakle.md
@@ -104,6 +104,21 @@ layout: t
 </div>
 
 
+{% comment %} Each modal lists the same upcoming showtimes as the play card. {% endcomment %}
+{% assign modal_all_miesiace = "styczen,luty,marzec,kwiecien,maj,czerwiec,lipiec,sierpien,wrzesien,pazdziernik,listopad,grudzien" | split: ',' %}
+{% assign modal_now = 'now' | date: "%s" | plus: 0 %}
 {% for s in collections.s2 %}
-  {% render "spektakl_modal.html", s: s %}
+  {% assign modal_events = "" | split: "" %}
+  {% for miesiac in modal_all_miesiace %}
+    {% if spektakle[miesiac].repertuar %}
+      {% for event in spektakle[miesiac].repertuar %}
+        {% assign ets = event.data | date: "%s" | plus: 0 %}
+        {% if event.tytul == s.title and ets >= modal_now %}
+          {% assign modal_events = modal_events | push: event %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+  {% assign modal_events = modal_events | sort: 'data' %}
+  {% render "spektakl_modal.html", s: s, events: modal_events %}
 {% endfor %}


### PR DESCRIPTION
Refs #43

Makes the play card's click target clear and richer:

1. **Whole card is one click target** — the card carries Bootstrap's `.stretched-link` so a click anywhere opens the play's details modal (chosen from a live prototype of three options: whole-card / whole-card+badge / explicit button). The video facade and each "Kup bilet" / "Zadzwoń" link stay independently clickable.
2. **Showtimes replicated inside the modal** — the mini-ticket list is extracted into a shared `_includes/play_tickets.html` and rendered both on the card and in a new "Najbliższe terminy" section of the details modal, so opening a card surfaces its tickets (buy links included). Each page (`t/spektakle.md`, `t/index.md`) passes the play's upcoming, sorted events into the modal.

Plays have no standalone page (`permalink:false`), so all paths open the same modal. `mise run build` passes; verified in-browser (whole-card click opens the modal; the modal lists the play's showtimes).